### PR TITLE
Added new 'test-results' command.

### DIFF
--- a/betelgeuse.py
+++ b/betelgeuse.py
@@ -16,6 +16,7 @@ import ssl
 import testimony
 import time
 
+from collections import Counter
 from pylarion.exceptions import PylarionLibException
 from pylarion.work_item import TestCase, Requirement
 from pylarion.test_run import TestRun
@@ -95,6 +96,18 @@ def parse_junit(path):
 
         result.append(data)
     return result
+
+
+def parse_test_results(test_results):
+    """Returns the summary of test results by their status.
+
+    :param test_results: A list of dicts with information about
+        test results, such as those reported in a JUNIT file.
+    :return: A dictionary containing a summary for all test results
+        provided by the ``test_results`` parameter, broken down by their
+        status.
+    """
+    return Counter([test['status'] for test in test_results])
 
 
 @click.group()
@@ -209,11 +222,27 @@ def test_case(path, collect_only, project):
                     test_case.update()
 
 
+@cli.command('test-results')
+@click.option(
+    '--path',
+    default='junit-results.xml',
+    help='Path to the JUNIT XML file.',
+    type=click.Path(exists=True, dir_okay=False),
+)
+def test_results(path):
+    """Shows a summary for test cases contained in a JUNIT xml file."""
+    test_summary = parse_test_results(parse_junit(path))
+    summary = '\n'.join(
+        ["{0}: {1}".format(*status) for status in test_summary.items()]
+    ).title()
+    click.echo(summary)
+
+
 @cli.command('test-run')
 @click.option(
     '--path',
     default='junit-results.xml',
-    help='Path to the jUnit XML file.',
+    help='Path to the JUNIT xml file.',
     type=click.Path(exists=True, dir_okay=False),
 )
 @click.option(

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,5 @@
 from StringIO import StringIO
-from betelgeuse import parse_junit, parse_requirement_name
+from betelgeuse import parse_junit, parse_requirement_name, parse_test_results
 
 
 JUNIT_XML = """<testsuite tests="4">
@@ -38,3 +38,43 @@ def test_parse_requirement_name():
     ]
     for name in names:
         assert parse_requirement_name(name) == 'Compute Resource'
+
+
+def test_parse_test_results():
+    test_results = [
+        {'status': u'passed',
+         'name': 'test_positive_read',
+         'classname': 'tests.api.test_ReadTestCase',
+         'file': 'tests/api/test_foo.py',
+         'time': '4.13224601746',
+         'line': '521'},
+        {'status': u'passed',
+         'name': 'test_positive_delete',
+         'classname': 'tests.api.test_ReadTestCase',
+         'file': 'tests/api/test_foo.py',
+         'time': '4.13224601746',
+         'line': '538'},
+        {'status': u'failure',
+         'name': 'test_negative_read',
+         'classname': 'tests.api.test_ReadTestCase',
+         'file': 'tests/api/test_foo.py',
+         'time': '4.13224601746',
+         'line': '218'},
+        {'status': u'skipped',
+         'name': 'test_positive_update',
+         'classname': 'tests.api.test_ReadTestCase',
+         'file': 'tests/api/test_foo.py',
+         'time': '4.13224601746',
+         'line': '112'},
+        {'status': u'error',
+         'name': 'test_positive_create',
+         'classname': 'tests.api.test_ReadTestCase',
+         'file': 'tests/api/test_foo.py',
+         'time': '4.13224601746',
+         'line': '788'},
+    ]
+    summary = parse_test_results(test_results)
+    assert summary['passed'] == 2
+    assert summary['failure'] == 1
+    assert summary['skipped'] == 1
+    assert summary['error'] == 1


### PR DESCRIPTION
Newly added 'test-results' command will display a brief test results summary for a
given JUNIT xml file.

Example:

``` shell
$ betelgeuse test-results --path ~/Downloads/rhel6-tier1.xml
Failure: 18 Skipped: 79 Passed: 876 Error: 9
```
