### PR TITLE
Introduce multiprocessing support

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -32,12 +32,8 @@ def test_parse_junit():
 
 
 def test_parse_requirement_name():
-    names = [
-        'tests.foreman.api.test_compute_resource.ClassName.test_method',
-        'tests.foreman.api.test_compute_resource.test_method',
-    ]
-    for name in names:
-        assert parse_requirement_name(name) == 'Compute Resource'
+    assert parse_requirement_name(
+        'tests/path/to/test_my_test_module.py') == 'My Test Module'
 
 
 def test_parse_test_results():


### PR DESCRIPTION
Add a new option to betelgeuse command, the `-j or --jobs`, in order
to allow beteulgeuse do its operations on more than one process:
- If nothing is specified, just one worker processes will be used;
- If `auto` is specified, N worker processes will be used, where N will
  be the number of CPU cores available on the running machine.
- If `N` is specified, N worker processes will be used.

Both test-case and test-run subcommands take advantage of the
multiprocessing feature.
