### PR TITLE
Added new `create-plan` command.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ import re
 
 from click.testing import CliRunner
 from betelgeuse import (
-    INVALID_TEST_RUN_CHARS_REGEX,
+    INVALID_CHARS_REGEX,
     RST_PARSER,
     JobNumberParamType,
     PylarionLibException,
@@ -227,7 +227,7 @@ def test_get_multiple_steps_diff_items():
 
 def test_invalid_test_run_chars_regex():
     invalid_test_run_id = '\\/.:*"<>|~!@#$?%^&\'*()+`,='
-    assert re.sub(INVALID_TEST_RUN_CHARS_REGEX, '', invalid_test_run_id) == ''
+    assert re.sub(INVALID_CHARS_REGEX, '', invalid_test_run_id) == ''
 
 
 def test_job_param_type():


### PR DESCRIPTION
Added a new `create-plan` command which allows one to create a new Test Plan
into Polarion. There are two possible types of Test Runs one can create:
Releases or Iterations. Furthermore, one can create a new Test Plan as a child
of an existing Test Plan (regardless of their types).

This new command will first query for a Test Run that matches the passed `name`
argument. If a match is found, then an instance of a `Test Plan` will be
returned. Otherwise, a new Test Plan will be created and returned.
