### PR TITLE
test name fix and id token quoting

### DIFF
--- a/betelgeuse.py
+++ b/betelgeuse.py
@@ -371,6 +371,7 @@ def add_test_case(args):
         # Fetch the test case id if the @Id tag is present otherwise generate a
         # test_case_id based on the test Python import path
         test_case_id = test.tokens.get('id', generate_test_id(test))
+        test.name = test.tokens.get('title', test_case_id)
         if test.docstring:
             if not type(test.docstring) == unicode:
                 test.docstring = test.docstring.decode('utf8')
@@ -414,6 +415,7 @@ def add_test_case(args):
 
         results = []
         if not collect_only:
+            test_case_id = '"{}"'.format(test_case_id)
             results = TestCase.query(
                 test_case_id,
                 fields=[
@@ -595,6 +597,7 @@ def cli(context, jobs):
         'subtype1',
         'testtype',
         'upstream',
+        'title',
     ]
     testimony.SETTINGS['minimum_tokens'] = ['id']
 

--- a/betelgeuse.py
+++ b/betelgeuse.py
@@ -371,7 +371,7 @@ def add_test_case(args):
         # Fetch the test case id if the @Id tag is present otherwise generate a
         # test_case_id based on the test Python import path
         test_case_id = test.tokens.get('id', generate_test_id(test))
-        test.name = test.tokens.get('title', test_case_id)
+        test.name = test.tokens.get('title', test.name)
         if test.docstring:
             if not type(test.docstring) == unicode:
                 test.docstring = test.docstring.decode('utf8')

--- a/tests.py
+++ b/tests.py
@@ -93,7 +93,7 @@ def test_add_test_case_create():
             patches['Requirement'].create.assert_called_once_with(
                 'PROJECT', 'Module', '', reqtype='functional')
             patches['TestCase'].query.assert_called_once_with(
-                'path.to.test_module.NameTestCase.test_name',
+                '"path.to.test_module.NameTestCase.test_name"',
                 fields=[
                     'caseautomation',
                     'caseposneg',
@@ -112,7 +112,7 @@ def test_add_test_case_create():
                 caseposneg='positive',
                 setup=None,
                 subtype1='-',
-                test_case_id='path.to.test_module.NameTestCase.test_name',
+                test_case_id='"path.to.test_module.NameTestCase.test_name"',
                 testtype='functional',
                 upstream='no',
             )


### PR DESCRIPTION
test name fix:
- If @Title token is provided, use that for test.name
- If not, use @Id if it is provided.
- If not, use function name default.

id token quoting:
- wrapped test_case_id in quotes before adding to allow spaces in Id

Signed-off-by: Scott Poore spoore@redhat.com
