### PR TITLE
Add xml-test-run command

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 flake8
 flake8-docstrings
 flake8-quotes
+pydocstyle==1.0.0  # https://github.com/PyCQA/pydocstyle/issues/207
 
 # For `make package`
 wheel


### PR DESCRIPTION
The xml-test-run command creates a XML file based on a provided jUnit XML
report and the source code. The generated XML is intended to be used by the XML
importer.

Close #80

EDIT: added a second commit to fix the travis failure, it is just a dependency issue.
