### PR TITLE
Force consistent case in metadata fields - fixes #118

### DIFF
--- a/betelgeuse/parser.py
+++ b/betelgeuse/parser.py
@@ -174,7 +174,7 @@ def parse_docstring(docstring=None):
         field_names = field_list.getElementsByTagName('dt')
         field_values = field_list.getElementsByTagName('dd')
         for field_name, field_value in zip(field_names, field_values):
-            field_name = field_name.firstChild.nodeValue
+            field_name = field_name.firstChild.nodeValue.lower()
             output = ''
             if (len(field_value.childNodes) == 2 and
                     field_value.childNodes[0].tagName == 'p'):


### PR DESCRIPTION
When parsing docstrings, force metadata field keys to be lowercase. Field keys are considered case-insensitive for all intents and purposes anyway, but without this change, it could happen that more generic data (on module level) overwritten more specific data (on function level). See issue #118 for details of problem and background info.

For regression testing, I have run betelgeuse with and without this change on [known bad version of Robottelo repository](https://github.com/SatelliteQE/robottelo/tree/447f1bd68501d7be99ecbea6a1e1503186ec4fb9), using commands that we use in Satellite CI ([satellite6-betelgeuse-test-case.sh](https://github.com/SatelliteQE/robottelo-ci/blob/master/scripts/satellite6-betelgeuse-test-case.sh) and [satellite6-betelgeuse-test-run.sh](https://github.com/SatelliteQE/robottelo-ci/blob/master/scripts/satellite6-betelgeuse-test-run.sh)). I have captured all stdout and xml files for both invocations and then compared changes with `diff`. Only changes were in results of `test-case` subcommand, and they were consistent with my expectations - i.e. correct values from function level were used.

Please let me know if you need anything else to merge this change.