### PR TITLE
Python versions updated in checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Updated Python Versions in checks :
- Removed 3.6 and 3.7 as old versions
- Kept 3.8
- Added 3.9 and 3.10