### PR TITLE
Test Markers as Test Fields

### DIFF
--- a/betelgeuse/__init__.py
+++ b/betelgeuse/__init__.py
@@ -656,7 +656,7 @@ def test_case(
     testcases.append(properties)
 
     source_testcases = itertools.chain(*collector.collect_tests(
-        source_code_path, collect_ignore_path).values())
+        source_code_path, collect_ignore_path, config=config).values())
     for testcase in source_testcases:
         testcases.append(
             create_xml_testcase(config, testcase, automation_script_format))

--- a/betelgeuse/__init__.py
+++ b/betelgeuse/__init__.py
@@ -423,7 +423,7 @@ def get_requirement_field_values(config, requirement):
 
 def update_testcase_fields(config, testcase):
     """Apply testcase fields default values and transformations."""
-    if testcase.docstring and not type(testcase.docstring) == str:
+    if testcase.docstring and not isinstance(testcase.docstring, str):
         testcase.docstring = testcase.docstring.decode('utf8')
 
     # Check if any field needs a default value

--- a/betelgeuse/parser.py
+++ b/betelgeuse/parser.py
@@ -1,4 +1,5 @@
 """Parsers for test docstrings."""
+import re
 from collections import namedtuple
 from io import StringIO
 from xml.dom import minidom
@@ -200,14 +201,21 @@ def parse_markers(all_markers=None, config=None):
     resolved_markers = []
     ignore_list = getattr(config, 'MARKERS_IGNORE_LIST', None)
 
-    def _process_marker(marker):
-        # Fetching exact marker name
-        marker_name = marker.split('mark.')[-1]
+    def _process_marker(_marker):
+
+        marker_name = re.findall(
+            r'(?:pytest\.mark\.)?([^(\s()]+)(?=\s*\(|\s*$)', _marker)
+        if marker_name:
+            marker_name = marker_name[0]
 
         # ignoring the marker if in ignore list
         if ignore_list and any(
-                ignore_word in marker_name for ignore_word in ignore_list):
+                re.fullmatch(
+                    ignore_word, marker_name
+                ) for ignore_word in ignore_list
+        ):
             return
+
         resolved_markers.append(marker_name)
 
     for sec_marker in all_markers:

--- a/betelgeuse/parser.py
+++ b/betelgeuse/parser.py
@@ -189,18 +189,26 @@ def parse_docstring(docstring=None):
     return fields_dict
 
 
-def parse_markers(all_markers=None):
-    """Parse the markers."""
-    ignore_list = ['parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
+def parse_markers(all_markers=None, config=None):
+    """Parse the markers from module, class and test level for a test.
+
+    This removes the mark prepended words and also pops out the
+    ignorable marker from the list received from the config object.
+
+    :returns string: Comma separated list of markers from all levels for a test
+    """
     resolved_markers = []
+    ignore_list = getattr(config, 'MARKERS_IGNORE_LIST', None)
 
     def _process_marker(marker):
         # Fetching exact marker name
-        marker_name = marker.split('mark.')[-1] if 'mark' in marker else marker
+        marker_name = marker.split('mark.')[-1]
 
         # ignoring the marker if in ignore list
-        if not any(ignore_word in marker_name for ignore_word in ignore_list):
-            resolved_markers.append(marker_name)
+        if ignore_list and any(
+                ignore_word in marker_name for ignore_word in ignore_list):
+            return
+        resolved_markers.append(marker_name)
 
     for sec_marker in all_markers:
         # If the marker is none
@@ -212,5 +220,4 @@ def parse_markers(all_markers=None):
         else:
             _process_marker(sec_marker)
 
-    resolved_markers = ', '.join(resolved_markers)
-    return resolved_markers
+    return ', '.join(resolved_markers)

--- a/betelgeuse/parser.py
+++ b/betelgeuse/parser.py
@@ -187,3 +187,30 @@ def parse_docstring(docstring=None):
             field_value = output
             fields_dict[field_name] = field_value
     return fields_dict
+
+
+def parse_markers(all_markers=None):
+    """Parse the markers."""
+    ignore_list = ['parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
+    resolved_markers = []
+
+    def _process_marker(marker):
+        # Fetching exact marker name
+        marker_name = marker.split('mark.')[-1] if 'mark' in marker else marker
+
+        # ignoring the marker if in ignore list
+        if not any(ignore_word in marker_name for ignore_word in ignore_list):
+            resolved_markers.append(marker_name)
+
+    for sec_marker in all_markers:
+        # If the marker is none
+        if not sec_marker:
+            continue
+        elif isinstance(sec_marker, list):
+            for marker in sec_marker:
+                _process_marker(marker)
+        else:
+            _process_marker(sec_marker)
+
+    resolved_markers = ', '.join(resolved_markers)
+    return resolved_markers

--- a/tests/data/test_sample.py
+++ b/tests/data/test_sample.py
@@ -1,7 +1,10 @@
 # encoding=utf-8
 """Sample test module."""
 import unittest
+import pytest
 
+
+pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.tier1]
 
 CONSTANT = 'contant-value'
 
@@ -72,3 +75,14 @@ class TestCase(unittest.TestCase):
 
     def test_without_docstring(self):  # noqa: D102
         pass
+
+
+@pytest.mark.on_prem_provisioning
+class TestclasswithMarkers:
+    """Class to verify tests markers are collected from class."""
+
+    @pytest.mark.skipif(2 == 3, reason='2 is not 3')
+    @pytest.mark.osp
+    def test_markers_sample(self):
+        """Test for markers at test level."""
+        assert True

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -11,7 +11,7 @@ def test_collect_tests(path):
     """Check if ``collect_tests`` 'tests/data'collect tests."""
     tests = collector.collect_tests(path)
     assert 'tests/data/test_sample.py' in tests
-    assert len(tests['tests/data/test_sample.py']) == 4
+    assert len(tests['tests/data/test_sample.py']) == 5
 
     # Check if we are not doing a specific python module collection
     if path.endswith('.py'):
@@ -30,7 +30,7 @@ def test_collect_ignore_path(ignore_path):
     tests = collector.collect_tests('tests/data', [ignore_path])
     assert 'tests/data/ignore_dir/test_ignore_dir.py' not in tests
     assert 'tests/data/test_sample.py' in tests
-    assert len(tests['tests/data/test_sample.py']) == 4
+    assert len(tests['tests/data/test_sample.py']) == 5
 
 
 @pytest.mark.parametrize('filename', ('test_module.py', 'module_test.py'))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Tests for :mod:`betelgeuse.parser`."""
 import pytest
+import mock
 
 from betelgeuse import parser
 
@@ -92,7 +93,7 @@ def test_parse_markers():
     List should be comma separated list of markers from all levels after
     removing 'pytest.mark' text and ignore some markers.
     """
-    _mod_markers = ['pytest.mark.e2e', 'pytest.mark.destructive']
+    _mod_markers = 'pytest.mark.destructive'
     _class_markers = [
         'pytest.mark.on_prem_provisioning',
         "pytest.mark.usefixtures('cleandir')"
@@ -104,6 +105,8 @@ def test_parse_markers():
     ]
     _all_markers = [_mod_markers, _class_markers, _test_markers]
 
-    expected = 'e2e, destructive, on_prem_provisioning, tier1'
-
-    assert parser.parse_markers(_all_markers) == expected
+    expected = 'destructive, on_prem_provisioning, tier1'
+    config = mock.MagicMock()
+    config.MARKERS_IGNORE_LIST = [
+        'parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
+    assert parser.parse_markers(_all_markers, config=config) == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -83,3 +83,27 @@ def test_parse_rst_special_characters():
         u'<p>String with special character like é</p>\n'
         u'</main>\n'
     )
+
+
+def test_parse_markers():
+    """
+    Test if the markers list is parsed.
+
+    List should be comma separated list of markers from all levels after
+    removing 'pytest.mark' text and ignore some markers.
+    """
+    _mod_markers = ['pytest.mark.e2e', 'pytest.mark.destructive']
+    _class_markers = [
+        'pytest.mark.on_prem_provisioning',
+        "pytest.mark.usefixtures('cleandir')"
+    ]
+    _test_markers = [
+        "pytest.mark.parametrize('something', ['a', 'b'])",
+        'pytest.mark.skipif(not settings.robottelo.REPOS_HOSTING_URL)',
+        'pytest.mark.tier1'
+    ]
+    _all_markers = [_mod_markers, _class_markers, _test_markers]
+
+    expected = 'e2e, destructive, on_prem_provisioning, tier1'
+
+    assert parser.parse_markers(_all_markers) == expected

--- a/tests/test_source_generator.py
+++ b/tests/test_source_generator.py
@@ -37,3 +37,14 @@ def test_source_generator():
         '(lambda v: (v if v else None))'
         ')',
     ]
+
+
+def test_source_markers():
+    """Verifies if the test collection collects test markers."""
+    tests = collector.collect_tests('tests/data/test_sample.py')
+    marked_test = [
+        test for test in tests['tests/data/test_sample.py']
+        if test.name == 'test_markers_sample'
+    ].pop()
+    assert marked_test.fields['markers'] == ('run_in_one_thread, tier1, '
+                                             'on_prem_provisioning, osp')


### PR DESCRIPTION
This PR allows Betelgeuse to :
- Add test markers as test fields while importing the test cases to Polarion

By:
- Read test and class decorators and parse them to filter only markers
- New functions to read test module level markers using ast methods
- The custom config now supports the dynamic list of ignorable markers.
- Filter out some decorators / markers which need not to be in the markers list

Helps in:
- Filtering the tests in polarion using markers 
- Generate reports based on markers like e2e, sanity, tiers etc