### PR TITLE
Typo fixes

### DIFF
--- a/betelgeuse/__init__.py
+++ b/betelgeuse/__init__.py
@@ -53,7 +53,7 @@ OBJ_CACHE = {'requirements': {}}
 
 
 def validate_key_value_option(ctx, param, value):
-    """Validate an option that expects key=value formated values."""
+    """Validate an option that expects key=value formatted values."""
     if value is None:
         return
     try:
@@ -234,12 +234,12 @@ def cli(ctx, config_module):
 @cli.command('requirement')
 @click.option(
     '--approver',
-    help='Whom the requirments will be approved by.',
+    help='Whom the requirements will be approved by.',
     multiple=True,
 )
 @click.option(
     '--assignee',
-    help='Whom the requirments will be assigned to.',
+    help='Whom the requirements will be assigned to.',
 )
 @click.option('--team', help='Team owning the requirement.',)
 @click.option(

--- a/betelgeuse/collector.py
+++ b/betelgeuse/collector.py
@@ -39,7 +39,7 @@ class TestFunction(object):
             #: set, otherwise it will be ``None``
             self.parent_class = parent_class.name
             #: If the testcase is a method then the parent ``ast.ClasDef``
-            #: representation of the parent calss will be set, otherwise it
+            #: representation of the parent class will be set, otherwise it
             #: will be ``None``
             self.parent_class_def = parent_class
             #: If test case is a method then the parent class docstring will be
@@ -72,7 +72,7 @@ class TestFunction(object):
             self.pkginit_def = None
             self.pkginit_docstring = None
         #: The dictionary that will store the field values defined for the
-        #: testcase. The field value resolution order is the test funtion or
+        #: testcase. The field value resolution order is the test function or
         #: method docstring, the class docstring if it is a method, the module
         #: docstring and finally the ``__init__.py`` docstring if present. The
         #: first value found the search will stop.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -175,8 +175,8 @@ does not validate the values on Polarion.
 .. literalinclude:: ../betelgeuse/default_config.py
     :linenos:
 
-Rquirement objects
-==================
+Requirement objects
+===================
 
 .. autoclass:: betelgeuse.collector.Requirement
     :members:


### PR DESCRIPTION
- "calss" -> "class"
- "formated" -> "formatted
- "funtion" -> "function"
- "requirments" -> "requirements"
- "rquirement" -> "requirement"

Found using codespell.

Adapt one rst header accordingly.