### PR TITLE
CI: switch testing to Python 3.10+

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Test the more recent versions of Python, to ensure Betelgeuse works
also with these versions. The oldest versions are dropped, leaving only
the latest 3 versions of Python.